### PR TITLE
Don't convert <img> elements with extra attributes

### DIFF
--- a/src/converters.coffee
+++ b/src/converters.coffee
@@ -4,7 +4,7 @@ indent = require 'indent'
 
 languageCodeRewrite = require '../lib/language-code-rewrites'
 treeAdapter = require './tree-adapter'
-{delimitCode, getAttribute, isBlock} = require './utils'
+{delimitCode, getAttribute, noExtraAttributes, isBlock} = require './utils'
 {
   extractRows
   formatHeaderSeparator
@@ -109,7 +109,9 @@ module.exports = [
         "[#{content}](#{url})"
   }
   {
-    filter: 'img'
+    filter: (node) ->
+      # Ignore img nodes that have custom styling or other attributes
+      node.tagName is 'img' and noExtraAttributes(node, 'alt', 'src', 'title')
     surroundingBlankLines: false
     replacement: (content, node, links) ->
       alt = getAttribute(node, 'alt') or ''

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -25,6 +25,13 @@ delimitCode = (code, delimiter) ->
 getAttribute = (node, attribute) ->
   _.find(getAttrList(node), name: attribute)?.value or null
 
+###*
+ * Check if node has more attributes than ones provided
+ * @return {boolean} true if no extra attributes otherwise false
+###
+noExtraAttributes = (node, attributes...) ->
+  _.isEmpty(_.without(_.map(getAttrList(node), 'name'), attributes...))
+
 cleanText = (node) ->
   parent = node.parentNode
   text = decodeHtmlEntities(getTextNodeContent(node))
@@ -64,6 +71,7 @@ module.exports = {
   decodeHtmlEntities
   delimitCode
   getAttribute
+  noExtraAttributes
   isBlock
   isVoid
 }

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -619,6 +619,16 @@ describe 'inline grammar', ->
       '![alt text](/path/to/img.jpg "Title")'
     )
 
+  it 'should convert <img> tags', ->
+    tidyMdSnippet('<img src="/path/to/img.jpg" alt="Image"/>').should.equal('![Image](/path/to/img.jpg)')
+
+  it 'should ignore <img> tags with extra attributes', ->
+    tidyMdSnippet(
+      '<img src="/path/to/img.jpg" alt="Image" style="width:50px;">'
+    ).should.equal(
+      '<img src="/path/to/img.jpg" alt="Image" style="width:50px;">'
+    )
+
   it 'should handle images in links', ->
     tidyMdSnippet(
       '[![text]( image.jpg )]( #anchor )'


### PR DESCRIPTION
Extra attributes such as `style` or `aria-describedby` cannot be
represented in markdown but are still reasonably important.

This would fix #55.

I added a couple test cases.  I don't use coffee script regularly so let me know if I got any conventions wrong.